### PR TITLE
feat: create logger

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,6 +1,4 @@
-type Type = 'ACTION' | 'QUERY'
-
-type Identifier = `${Uppercase<string>}_${Type}_ERROR`
+import type { Identifier } from './logger'
 
 export class HandlerError extends Error {
   public status: number

--- a/lib/handler.ts
+++ b/lib/handler.ts
@@ -2,6 +2,7 @@ import z from 'zod'
 import type { NextFunction, Request, RequestHandler, Response } from 'express'
 
 import { HandlerError } from './errors'
+import { logger } from './logger'
 
 class Handler<Values extends unknown | null, Params extends unknown | null> {
   #valuesSchema = null as z.Schema<Values> | null
@@ -43,7 +44,7 @@ class Handler<Values extends unknown | null, Params extends unknown | null> {
       await callback(args)
     } catch (error) {
       if (error instanceof HandlerError) {
-        // TODO: log the error with the identifier
+        logger.error({ identifier: error.identifier, message: error.message })
         return args.res.status(error.status).json({ error: error.message })
       }
 

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,23 @@
+type Scope = 'action' | 'query' | 'database' | 'server'
+export type Identifier = `${Scope}_${Lowercase<string>}`
+
+type Parameter = { identifier: Identifier; message: string }
+
+const colors = {
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  reset: '\x1b[0m',
+}
+
+export const logger = {
+  error: ({ identifier, message }: Parameter) => {
+    console.error(
+      `${colors.red}[${identifier}_error]${colors.reset}: ${message}`,
+    )
+  },
+  information: ({ identifier, message }: Parameter) => {
+    console.log(
+      `${colors.green}[${identifier}_information]${colors.reset}: ${message}`,
+    )
+  },
+}


### PR DESCRIPTION
close #11 

- create logger for `error` and `information`
- format with identifier, message and colors
- add logger for server errors in `handler`

<img width="488" alt="image" src="https://github.com/user-attachments/assets/2bafe2b4-b6a5-428d-b800-3f6b3409c641" />