### PR TITLE
fix: refresh token cookie

### DIFF
--- a/controller/auth.ts
+++ b/controller/auth.ts
@@ -76,6 +76,10 @@ export const authController = {
         process.env.REFRESH_TOKEN_SECRET!,
       )
 
-      res.status(200).json({ accessToken, refreshToken })
+      res.cookie('refreshToken', refreshToken, {
+        httpOnly: true,
+        secure: true,
+      })
+      res.status(200).json({ accessToken })
     }),
 }

--- a/controller/auth.ts
+++ b/controller/auth.ts
@@ -69,11 +69,12 @@ export const authController = {
       const accessToken = jwt.sign(
         { userId: user._id },
         process.env.ACCESS_TOKEN_SECRET!,
-        { expiresIn: '1h' },
+        { expiresIn: '15m' },
       )
       const refreshToken = jwt.sign(
         { userId: user._id },
         process.env.REFRESH_TOKEN_SECRET!,
+        { expiresIn: '7d' },
       )
 
       res.cookie('refreshToken', refreshToken, {


### PR DESCRIPTION
store refresh token in an httpOnly cookie so that it is not accessible by javascript on the client. also added and updated `expiresIn`