### PR TITLE
feat: refresh token endpoint

### DIFF
--- a/api/routes.ts
+++ b/api/routes.ts
@@ -14,7 +14,7 @@ const authRouter = Router()
 authRouter.post('/register', upload.single('image'), authController.register)
 authRouter.post('/log-in', authController.login)
 authRouter.delete('/log-out', authController.logout)
-authRouter.post('/token/refresh')
+authRouter.post('/token/refresh', authController.refreshToken)
 
 router.use('/auth', authRouter)
 

--- a/models/refresh-token.ts
+++ b/models/refresh-token.ts
@@ -1,0 +1,14 @@
+import { type InferSchemaType, model, Schema } from 'mongoose'
+
+const schema = new Schema({
+  token: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+})
+
+export const RefreshToken = model<InferSchemaType<typeof schema>>(
+  'RefreshToken',
+  schema,
+)


### PR DESCRIPTION
- create refresh token endpoint
- store refresh tokens in the database to ensure they can only be used once