### PR TITLE
refactor: simplify image model

### DIFF
--- a/models/capsule.ts
+++ b/models/capsule.ts
@@ -1,6 +1,6 @@
 import { InferSchemaType, model, Schema } from 'mongoose'
 
-import { ImageSchema, imageSchema } from '../schemas/image'
+import { imageSchema } from '../schemas/image'
 import { z } from 'zod'
 
 const lockValidation = {
@@ -74,8 +74,6 @@ schema.method('isUnlocked', function () {
 type CapsuleMethods = {
   isUnlocked: () => boolean
 }
-type CapsuleSchema = Omit<InferSchemaType<typeof schema>, 'images'> & {
-  images: ImageSchema[]
-}
+type CapsuleSchema = InferSchemaType<typeof schema>
 
 export const Capsule = model<CapsuleSchema & CapsuleMethods>('Capsule', schema)

--- a/models/user.ts
+++ b/models/user.ts
@@ -2,7 +2,7 @@ import { InferSchemaType, model, MongooseError, Schema } from 'mongoose'
 import { z } from 'zod'
 import bcrypt from 'bcrypt'
 
-import { ImageSchema, imageSchema } from '../schemas/image'
+import { imageSchema } from '../schemas/image'
 import { logger } from '../lib/logger'
 
 const schema = new Schema(
@@ -76,8 +76,4 @@ schema.pre('save', async function (next) {
   }
 })
 
-type UserSchema = Omit<InferSchemaType<typeof schema>, 'image'> & {
-  image: ImageSchema | undefined
-}
-
-export const User = model<UserSchema>('User', schema)
+export const User = model<InferSchemaType<typeof schema>>('User', schema)

--- a/schemas/image.ts
+++ b/schemas/image.ts
@@ -1,14 +1,10 @@
-import { Schema, Types } from 'mongoose'
-import { z } from 'zod'
-
-import { objectIdSchema } from '../lib/validation'
+import { Schema } from 'mongoose'
 
 export const imageSchema = new Schema(
   {
     name: {
       type: String,
       required: true,
-      unique: true,
     },
     type: {
       type: String,
@@ -18,54 +14,8 @@ export const imageSchema = new Schema(
       type: Number,
       required: true,
     },
-    visibility: {
-      type: String,
-      enum: ['public', 'private'],
-      required: true,
-      default: 'private',
-    },
-    accessibleBy: {
-      type: [
-        {
-          type: Types.ObjectId,
-          ref: 'User',
-        },
-      ],
-      validate: {
-        validator(accessibleBy: unknown) {
-          if (!('visibility' in this)) {
-            return false
-          }
-
-          if (this.visibility === 'private') {
-            const schema = z.array(objectIdSchema).min(1)
-            const { success } = schema.safeParse(accessibleBy)
-            return success
-          }
-
-          if (this.visibility === 'public') {
-            const schema = z.tuple([])
-            const { success } = schema.safeParse(accessibleBy)
-            return success
-          }
-        },
-        message:
-          'private images must be accessible by at least one user, public images should not have an accessible by list',
-      },
-    },
   },
   {
     timestamps: true,
   },
 )
-
-// accessibleBy messes up the inference hence the manual declaration
-export type ImageSchema = {
-  name: string
-  type: string
-  size: number
-  visibility: 'public' | 'private'
-  createdAt: NativeDate
-  updatedAt: NativeDate
-  accessibleBy: Types.ObjectId[]
-}


### PR DESCRIPTION
remove `accessibleBy` and `visibility` from `Image`. since images will be retrieved through their capsule, it will handle who has access to the image