### PR TITLE
refactor: use `save()`

### DIFF
--- a/controller/auth.ts
+++ b/controller/auth.ts
@@ -29,8 +29,9 @@ const tokenResponse = async ({
     expiresIn: '7d',
   })
 
-  await RefreshToken.insertOne({ token: refreshToken })
+  const databaseRefreshToken = new RefreshToken({ token: refreshToken })
 
+  await databaseRefreshToken.save()
   res.cookie('refreshToken', refreshToken, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
@@ -51,7 +52,7 @@ export const authController = {
         throw new HandlerError('email or username already in use', 400)
       }
 
-      await User.create({
+      const user = new User({
         username,
         firstName,
         lastName,
@@ -60,6 +61,7 @@ export const authController = {
         image,
       })
 
+      await user.save()
       res.status(201).json({ message: 'user registered successfully' })
     },
     {

--- a/controller/user.ts
+++ b/controller/user.ts
@@ -5,6 +5,7 @@ import { imageSchema, objectIdSchema, usernameSchema } from '../lib/validation'
 import { User } from '../models/user'
 import { HandlerError, NotFoundError } from '../lib/errors'
 import { deleteFile } from '../lib/file'
+import { onlyDefinedValues } from '../lib/only-defined-values'
 
 export const userController = {
   getUserById: handle(
@@ -58,13 +59,16 @@ export const userController = {
         await deleteFile(oldImage.name)
       }
 
-      await user.updateOne({
-        username,
-        firstName,
-        lastName,
-        image,
-      })
+      user.set(
+        onlyDefinedValues({
+          username,
+          firstName,
+          lastName,
+          image,
+        }),
+      )
 
+      await user.save()
       res.status(204).send()
     },
     {
@@ -88,7 +92,6 @@ export const userController = {
       }
 
       await user.deleteOne()
-
       res.status(204).send()
     },
     { authenticate: true },

--- a/lib/only-defined-values.ts
+++ b/lib/only-defined-values.ts
@@ -1,0 +1,6 @@
+export const onlyDefinedValues = (object: Record<string, unknown>) => {
+  Object.keys(object).forEach(
+    (key) => object[key] === undefined && delete object[key],
+  )
+  return object
+}

--- a/models/capsule.ts
+++ b/models/capsule.ts
@@ -87,9 +87,8 @@ schema.method('isReceivedBy', function (userId: Types.ObjectId) {
 schema.pre('save', function (next) {
   if (!this.isModified('unlockDate')) {
     next()
+    return
   }
-
-  console.log('unlockDate modified')
 
   this.lockedAt = new Date()
   next()

--- a/models/user.ts
+++ b/models/user.ts
@@ -53,6 +53,7 @@ const schema = new Schema(
 schema.pre('save', async function (next) {
   if (!this.isModified('password')) {
     next()
+    return
   }
 
   try {
@@ -63,6 +64,7 @@ schema.pre('save', async function (next) {
   } catch (error) {
     if (error instanceof MongooseError) {
       next(error)
+      return
     }
 
     if (error instanceof Error) {


### PR DESCRIPTION
closes #83 

- use `save()` for create and update operations
- add return statements in schema hooks