### PR TITLE
refactor: add `state` to capsule model

### DIFF
--- a/controller/capsule.ts
+++ b/controller/capsule.ts
@@ -23,6 +23,7 @@ const filterCapsuleResponse = (
     openDate,
     sealedAt,
     visibility,
+    state,
     senders,
     receivers,
   } = capsule
@@ -40,6 +41,7 @@ const filterCapsuleResponse = (
         content,
         images,
         visibility,
+        state,
         showCountdown,
         senders,
         receivers,
@@ -48,6 +50,7 @@ const filterCapsuleResponse = (
       return {
         id: _id,
         openDate,
+        state,
       }
     case 'opened':
       return {
@@ -58,6 +61,7 @@ const filterCapsuleResponse = (
         openDate,
         sealedAt,
         visibility,
+        state,
         showCountdown,
         senders,
         receivers,
@@ -109,7 +113,7 @@ export const capsuleController = {
         throw new AuthError('you are not allowed to edit this capsule', 403)
       }
 
-      if (!(capsule.getState() === 'unsealed')) {
+      if (!(capsule.state === 'unsealed')) {
         throw new HandlerError('capsule is sealed and can not be edited', 423)
       }
 
@@ -168,8 +172,7 @@ export const capsuleController = {
         throw new NotFoundError('capsule not found')
       }
 
-      const { showCountdown, visibility } = capsule
-      const state = capsule.getState()
+      const { showCountdown, visibility, state } = capsule
 
       switch (state) {
         case 'unsealed':

--- a/models/capsule.ts
+++ b/models/capsule.ts
@@ -69,7 +69,7 @@ const schema = new Schema(
   },
 )
 
-schema.method('getState', function () {
+schema.virtual('state').get(function () {
   if (!this.openDate) return 'unsealed'
   if (this.openDate && this.openDate >= new Date()) return 'sealed'
   if (this.openDate && this.openDate <= new Date()) return 'opened'
@@ -94,12 +94,12 @@ schema.pre('save', function (next) {
 })
 
 type CapsuleMethods = {
-  getState: () => 'unsealed' | 'sealed' | 'opened'
   isSentBy: (userId: Types.ObjectId) => boolean
   isReceivedBy: (userId: Types.ObjectId) => boolean
 }
-type CapsuleSchema = InferSchemaType<typeof schema>
+type CapsuleSchema = InferSchemaType<typeof schema> & {
+  state: 'unsealed' | 'opened' | 'sealed'
+}
 
 export const Capsule = model<CapsuleSchema & CapsuleMethods>('Capsule', schema)
-
 export type TCapsule = CapsuleSchema & Document


### PR DESCRIPTION
closes #92

- add a virtual state field
- update places where `getState` is used